### PR TITLE
Set cursor to default

### DIFF
--- a/bad-html/style-file.css
+++ b/bad-html/style-file.css
@@ -13,6 +13,10 @@ body {
     font-family: "Tidenes Sans Regular", "Lato", sans-serif, Gotham, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
+a {
+    cursor: default !important;
+}
+
 a:focus {
     outline: 0;
 }


### PR DESCRIPTION
Set the cursor to default to hide all indications of clickable elements